### PR TITLE
added basic button implementation

### DIFF
--- a/src/storyblok/RichText.astro
+++ b/src/storyblok/RichText.astro
@@ -2,6 +2,7 @@
 import { storyblokEditable } from '@storyblok/astro';
 import { RichTextSchema, renderRichText } from '@storyblok/js';
 import UnionSearch from './nestable/UnionSearch.astro';
+import Button from './nestable/Button.astro';
 
 export interface Props {
   blok: {
@@ -62,6 +63,12 @@ const richTextParts = richTextString.split(/\[__COMPONENT:(__INDEX:\d+)\]/);
             return (
               <div {...storyblokEditable(storedComponent.params)}>
                 <UnionSearch blok={storedComponent.params} />
+              </div>
+            );
+          case 'button':
+            return (
+              <div {...storyblokEditable(storedComponent.params)}>
+                <Button blok={storedComponent.params} />
               </div>
             );
           default:

--- a/src/storyblok/nestable/Button.astro
+++ b/src/storyblok/nestable/Button.astro
@@ -1,0 +1,14 @@
+---
+import { storyblokEditable } from '@storyblok/astro';
+
+const { blok } = Astro.props
+---
+
+<div {...storyblokEditable(blok)}>
+<p class="text-center">
+    <!-- Note that blok.buttonLink.url will only work right now for external URLs in Storyblok, not internal links. 
+    Will need to create an if statement to accomodate internal links -->
+    <a href={blok.buttonLink.url} target="_blank" class="btn btn-primary btn-primary-outline mb-2"><i class={blok.buttonIcon}></i>{blok.buttonText}</a>
+</p>
+</div>
+


### PR DESCRIPTION
PR completes #37 with a basic implementation of a user-facing button component. @alexandergknoll, can you peek to make sure everything looks right? I basically added onto your if statement chain in `RichText.astro` to implement this one. (If this is right, I think I have a decent understanding of how to at least get other simple components spun up!)

One note (which is true across the site) is that the `blok.buttonLink.url` field only really works for external links right now because there is something that needs to be factored into the parsing of the code/API call to render internal links (see [this](https://www.storyblok.com/docs/guide/in-depth/rendering-the-link-field)). Right now, I'm not worrying about it, but I'm going to open an issue just to keep track of the components that have URL fields in them where we might need to figure this out.