### PR TITLE
41: use getPath helper to parse URL for link field

### DIFF
--- a/src/storyblok/Root.astro
+++ b/src/storyblok/Root.astro
@@ -1,4 +1,5 @@
 ---
+import { getPath } from '../lib/utils';
 import { storyblokEditable } from '@storyblok/astro';
 import EventCTA from "../components/Home/EventCTA.astro";
 import ArticleCTA from "../components/Home/ArticleCTA.astro";
@@ -45,7 +46,7 @@ const { blok } = Astro.props
                       <p class="text-white" data-swiper-parallax-x="100" data-swiper-parallax-duration="300">{slide.content}</p>
                     }
                     {(slide.button_link && slide.button_text) &&
-                      <a href={slide.button_link} class="btn btn-sm btn-secondary hero-button">
+                      <a href={getPath(slide.button_link.cached_url)} class="btn btn-sm btn-secondary hero-button">
                         {slide.button_text}
                       </a>
                     }


### PR DESCRIPTION
@emilyrbowe

This PR just uses the existing `getPath` helper that we already had to get the correct absolute URL of the link fields for home page slider.

I realized that these link fields do not have the story type when they reference a story, so we would ultimately have to make additional API calls for each linked story to get all of the properties and render it that way.  I think our `getPath` function already works and I also noticed that we get a `cached_url` property regardless of what the link type is set to.  Let me know if you think this works for now!