### PR TITLE
add script for image popups

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,4 +1,5 @@
-document.addEventListener("DOMContentLoaded", function(){
+document.addEventListener("DOMContentLoaded", function() {
+  // Add link to return to in-text footnote to each endnote
   const endnotes = document.querySelectorAll('[data-endnote]');
 
   endnotes.forEach((endnote) => {
@@ -19,6 +20,59 @@ document.addEventListener("DOMContentLoaded", function(){
 
         footnote.scrollIntoView();
       })
+    }
+  });
+
+  // Add popup hover images
+  const popupImageTriggers = document.querySelectorAll('a[data-popup][href]');
+
+  popupImageTriggers.forEach((popupImageTrigger) => {
+    const popupImageTooltip = document.createElement('div');
+    const xOffset = 100;
+    const yOffset = -20;
+
+    popupImageTooltip.classList.add('iiif-popup');
+
+    const imageHref = popupImageTrigger.getAttribute('href');
+
+    if (imageHref) {
+      popupImageTrigger.classList.add('popup-tooltip');
+
+      const bibSrc = popupImageTrigger.getAttribute('data-bib-src');
+      popupImageTrigger.addEventListener('click', function(e) {
+        e.preventDefault();
+
+        if (bibSrc) {
+          window.open(
+            bibSrc,
+            '_blank',
+          );
+        }
+      });
+
+      const popupImage = document.createElement('img');
+      popupImage.setAttribute('src', imageHref);
+      popupImageTooltip.append(popupImage);
+
+      const nbsp = document.createTextNode(' ');
+      popupImageTrigger.prepend(nbsp);
+
+      const externalLinkIcon = document.createElement('i');
+      externalLinkIcon.classList.add('fas', 'fa-external-link-alt');
+      popupImageTrigger.prepend(externalLinkIcon);
+
+      popupImageTrigger.addEventListener('mouseenter', function() {
+        document.body.append(popupImageTooltip);
+      });
+
+      popupImageTrigger.addEventListener('mouseleave', function() {
+        popupImageTooltip.remove();
+      });
+
+      popupImageTrigger.addEventListener('mousemove', function(e) {
+        popupImageTooltip.style.top = (e.pageY - xOffset) + 'px';
+        popupImageTooltip.style.left = (e.pageX - yOffset) + 'px';
+      });
     }
   });
 });

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -826,8 +826,8 @@ p { font-size: 14px; line-height: 14px; }
   }
 }
 
-span.popupTooltip {
-  background-image: linear-gradient(0deg, rgba(5, 70, 113, 0.30) 100%, transparent 0);
+.popup-tooltip {
+  background-image: linear-gradient(0deg, rgba(5, 70, 113, 0.30) 100%, transparent 0) !important;
   border-radius: 8px;
   padding: 2px 8px;
   z-index: 1000;
@@ -835,30 +835,30 @@ span.popupTooltip {
   
 }
 
-span.popupTooltip:hover {
-  background-image: linear-gradient(0deg, rgba(5, 70, 113, 0.10) 100%, transparent 0);
+.popup-tooltip:hover {
+  background-image: linear-gradient(0deg, rgba(5, 70, 113, 0.10) 100%, transparent 0) !important;
   z-index: 1000;
 }
 
-div.iiif-popup {
-  position:absolute; 
-  background:#1a1a37; 
-  padding:5px; color:#1a1a37; 
-  max-height:410px; 
-  max-width:410px;
+.iiif-popup {
+  position: absolute; 
+  background: #1a1a37; 
+  padding: 5px;
+  color: #1a1a37; 
+  max-height: 410px; 
+  max-width: 410px;
   min-width: 50px;
   min-height: 50px;
-  display:none;
   z-index: 1000;
   box-shadow: 2px 2px 3px rgba(0,0,0,0.7);
   border-radius: 2px;
 }
 
-div.iiif-popup {
+.iiif-popup {
   img {
-    border:none; 
-    max-width:400px; 
-    max-height:400px; 
+    border: none; 
+    max-width: 400px; 
+    max-height: 400px; 
     z-index: 1000;
   }
 }


### PR DESCRIPTION
To enable popup, create a link in any rich text field in Storyblok and use the `href` attribute for the image src and add the `data-popup=1` as an attribute for the link.

Optional parameter for `data-bib-src=[INSERT_LINK]` is also available.

Notable changes from current production instance of the site:

- Slight changes to style (spacing/color) for better consistency
- For popups with bib-src, the entire clickable target will launch the link to the bib-src instead of just the icon
- bib-src links open in a new tab

The following page in Storyblok has a popup converted using this new format in the first paragraph of the article:

https://www.leventhalmap.org/articles/florida-ruffin-ridley/