### PR TITLE
add cards to standard Storyblok page template

### DIFF
--- a/src/components/Page/Card.astro
+++ b/src/components/Page/Card.astro
@@ -1,0 +1,33 @@
+---
+import { useStoryblokApi } from "@storyblok/astro";
+import type { ISbResult } from "@storyblok/astro";
+import { getPath } from '../../lib/utils';
+
+export interface Props {
+	uuid: string;
+}
+
+const { uuid } = Astro.props;
+
+const storyblokApi = useStoryblokApi()
+ 
+const { data }: ISbResult = await storyblokApi.get('cdn/stories/' + uuid, {
+  version: String(import.meta.env.STORYBLOK_IS_PREVIEW) == 'true' ? 'draft' : 'published',
+  find_by: 'uuid',
+} as any)
+
+let page = data.story
+---
+
+
+<a href={getPath(page.full_slug)} class="card rounded-0 hover-shadow border-top-0 border-left-0 border-right-0 page-card">
+  {page.content.header_img && 
+    <img class="card-img-top rounded-0" src={page.content.header_img.filename} alt={page.name}>
+  }
+  <div class="card-body">
+    <h3 class="card-title not-content">{page.name}</h3>
+    {page.content.page_description && 
+      <p class="card-text">{page.content.page_description}</p>
+    }
+  </div>
+</a>

--- a/src/pages/[...path].astro
+++ b/src/pages/[...path].astro
@@ -57,17 +57,19 @@ const page = (data as any).story
 <Layout title={`${page.name}`} subheading={`${page.content.page_description ? page.content.page_description : ''}`} image={`${page.content.header_img && page.content.header_img.filename}`}>
   <section class="section-sm">
     <div class="row">
-      <div class="col-lg-8 order-1 order-lg-1">
+      <div class={`${!page.content.hide_sidebar ? 'col-lg-8 order-1 order-lg-1' : 'col-12'}`}>
         <div class="row">
           <div class="col-12 mb-5 content">
             <StoryblokComponent name={page.name} blok={page.content} />
           </div>
         </div>
       </div>
-      
-      <aside class="col-lg-4 order-2 order-lg-2 section-sidebar">
-        <Sidebar path={path} />
-      </aside>
+
+      {!page.content.hide_sidebar &&      
+        <aside class="col-lg-4 order-2 order-lg-2 section-sidebar">
+          <Sidebar path={path} />
+        </aside>
+      }
     </div>
   </section>
 </Layout>

--- a/src/storyblok/StandardLmecMainPage.astro
+++ b/src/storyblok/StandardLmecMainPage.astro
@@ -1,10 +1,12 @@
 ---
 import { storyblokEditable } from '@storyblok/astro';
 import RichText from '../storyblok/RichText.astro';
+import Card from '../components/Page/Card.astro';
 
 export interface Props {
 	blok: {
     body: any;
+    cards: string[];
   };
 }
 
@@ -14,5 +16,15 @@ const { blok } = Astro.props
 {blok.body && (
   <div {...storyblokEditable(blok)}>
     <RichText blok={{ body: blok.body }} />
+
+    {blok.cards &&
+      <div class="row">
+        {blok.cards.map((uuid: string) => (
+          <div class="col-lg-4 col-sm-6 mb-4">
+            <Card uuid={uuid} />
+          </div>
+        ))}
+      </div>
+    }
   </div>
 )}


### PR DESCRIPTION
@emilyrbowe - I ended up adding a "cards" field to the StandardLmecMainePage template since we query for that content type specifically when setting the static routes in Astro for these pages.

Here's the page I set up as a preview:  https://app.storyblok.com/#/me/spaces/1014956/stories/0/0/25849019/blok/4b19e564-48ca-4dfa-aa28-5311cfae8736

Let me know if you think this will work!