### PR TITLE
Bump Astro and Vite to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "animate.css": "^4.1.1",
         "astro": "^5.15.4",
         "astro-seo": "^0.8.4",
-        "bootstrap": "^5.3.3",
+        "bootstrap": "^5.3.8",
         "countable": "^3.0.1",
         "sass": "^1.85.1",
         "sharp": "^0.33.5",
@@ -2983,9 +2983,9 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "animate.css": "^4.1.1",
     "astro": "^5.15.4",
     "astro-seo": "^0.8.4",
-    "bootstrap": "^5.3.3",
+    "bootstrap": "^5.3.8",
     "countable": "^3.0.1",
     "sass": "^1.85.1",
     "sharp": "^0.33.5",


### PR DESCRIPTION
This one should be pretty self-explanatory.  I didn't notice any breaking changes!

Edit: also decided to bump Bootstrap from 5.3.3 to 5.3.8 (latest) since this should not contain any breaking changes (just to stay current)